### PR TITLE
Social

### DIFF
--- a/app/src/main/java/com/nemodream/bangkkujaengi/CustomerActivity.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/CustomerActivity.kt
@@ -126,6 +126,24 @@ class CustomerActivity : AppCompatActivity() {
                 else -> View.GONE
             }
         }
+
+//        회원일 경우: 네비게이션 바텀 아이템 클릭을 정상 처리
+//        navController.addOnDestinationChangedListener { _, destination, _ ->
+//            if (userType == "member") {
+//                binding.customerBottomNavigation.visibility = when (destination.id) {
+//                    in showBottomNavDestinations -> View.VISIBLE
+//                    else -> View.GONE
+//                }
+//            }else{
+//                when (destination.id) {
+//                    R.id.navigation_home -> {binding.customerBottomNavigation.visibility = View.VISIBLE}
+//                    R.id.navigation_social -> {
+//                        showGuestOnlyDialog()
+//                        binding.customerBottomNavigation.visibility = View.GONE }
+//                    R.id.navigation_my_page -> {binding.customerBottomNavigation.visibility = View.VISIBLE}
+//                }
+//            }
+//        }
     }
 
     companion object {

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/model/Post.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/model/Post.kt
@@ -3,7 +3,9 @@ package com.nemodream.bangkkujaengi.customer.data.model
 data class Post(
     // 게시글 고유 아이디
     val id: String = "",
-    // 작성자 아이디
+    // 작성자 고유 아이디
+    val memberDocId: String = "",
+    // 작성자 닉네임
     val nickname: String = "",
     // 작성자 프사
     val authorProfilePicture: String = "",

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/model/Tag.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/model/Tag.kt
@@ -1,9 +1,8 @@
 package com.nemodream.bangkkujaengi.customer.data.model
 
-
 data class Tag(
-    val order: Int? = null,
-    val tagX: Float ? = null,
-    val tagY: Float ? = null,
-    val tagProductInfo: Product ? = null
+    val order: Int? = null, // 사진이 몇번째인지의 정보
+    val tagX: Float ? = null, // 태그핀의 x위치
+    val tagY: Float ? = null, // 태그핀의 y위치
+    val tagProductInfo: Product ? = null // 태그핀이 가지고 있는 태그 상품 정보
 )

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialDiscoveryRepository.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialDiscoveryRepository.kt
@@ -28,6 +28,7 @@ class SocialDiscoveryRepository @Inject constructor(
     // Firebase Firestore에서 게시글 데이터 가져오기
     private fun DocumentSnapshot.toPost(): Post? {
         val id = getString("id") ?: return null
+        val memberDocId = getString("memberDocId") ?: return null
         val nickname = getString("nickname") ?: return null
         val authorProfilePicture = getString("authorProfilePicture") ?: return null
         val title = getString("title") ?: return null
@@ -39,6 +40,7 @@ class SocialDiscoveryRepository @Inject constructor(
 
         return Post(
             id = id,
+            memberDocId = memberDocId,
             nickname = nickname,
             authorProfilePicture = authorProfilePicture,
             title = title,

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialDiscoveryRepository.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialDiscoveryRepository.kt
@@ -4,6 +4,7 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
 import com.nemodream.bangkkujaengi.customer.data.model.Post
+import com.nemodream.bangkkujaengi.customer.data.model.Tag
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -34,6 +35,7 @@ class SocialDiscoveryRepository @Inject constructor(
         val imageList = get("imageList") as? List<String> ?: emptyList()
         val savedCount = getLong("savedCount")?.toInt() ?: 0
         val commentCount = getLong("commentCount")?.toInt() ?: 0
+        val productTagPinList = get("productTagPinList") as? List<Tag> ?: emptyList()
 
         return Post(
             id = id,
@@ -43,7 +45,8 @@ class SocialDiscoveryRepository @Inject constructor(
             content = content,
             imageList = imageList,
             savedCount = savedCount,
-            commentCount = commentCount
+            commentCount = commentCount,
+            productTagPinList = productTagPinList
         )
     }
 }

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialFollowingRepository.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialFollowingRepository.kt
@@ -53,6 +53,7 @@ class SocialFollowingRepository @Inject constructor(private val firestore: Fireb
     // Firebase Firestore에서 게시글 데이터 가져오기
     private fun DocumentSnapshot.toPost(): Post? {
         val id = getString("id") ?: return null
+        val memberDocId = getString("memberDocId") ?: return null
         val nickname = getString("nickname") ?: return null
         val authorProfilePicture = getString("authorProfilePicture") ?: return null
         val title = getString("title") ?: return null
@@ -64,6 +65,7 @@ class SocialFollowingRepository @Inject constructor(private val firestore: Fireb
 
         return Post(
             id = id,
+            memberDocId = memberDocId,
             nickname = nickname,
             authorProfilePicture = authorProfilePicture,
             title = title,

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialFollowingRepository.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialFollowingRepository.kt
@@ -6,6 +6,7 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.nemodream.bangkkujaengi.customer.data.model.Member
 import com.nemodream.bangkkujaengi.customer.data.model.Post
+import com.nemodream.bangkkujaengi.customer.data.model.Tag
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -59,6 +60,7 @@ class SocialFollowingRepository @Inject constructor(private val firestore: Fireb
         val imageList = get("imageList") as? List<String> ?: emptyList()
         val savedCount = getLong("savedCount")?.toInt() ?: 0
         val commentCount = getLong("commentCount")?.toInt() ?: 0
+        val productTagPinList = get("productTagPinList") as? List<Tag> ?: emptyList()
 
         return Post(
             id = id,
@@ -68,7 +70,8 @@ class SocialFollowingRepository @Inject constructor(private val firestore: Fireb
             content = content,
             imageList = imageList,
             savedCount = savedCount,
-            commentCount = commentCount
+            commentCount = commentCount,
+            productTagPinList = productTagPinList
         )
     }
 }

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialMyRepository.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialMyRepository.kt
@@ -45,6 +45,7 @@ class SocialMyRepository @Inject constructor(private val firestore: FirebaseFire
     // Firebase Firestore에서 게시글 데이터 가져오기
     private fun DocumentSnapshot.toPost(): Post? {
         val id = getString("id") ?: return null
+        val memberDocId = getString("memberDocId") ?: return null
         val nickname = getString("nickname") ?: return null
         val authorProfilePicture = getString("authorProfilePicture") ?: return null
         val title = getString("title") ?: return null
@@ -57,6 +58,7 @@ class SocialMyRepository @Inject constructor(private val firestore: FirebaseFire
 
         return Post(
             id = id,
+            memberDocId = memberDocId,
             nickname = nickname,
             authorProfilePicture = authorProfilePicture,
             title = title,

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialMyRepository.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialMyRepository.kt
@@ -6,6 +6,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
 import com.nemodream.bangkkujaengi.customer.data.model.Member
 import com.nemodream.bangkkujaengi.customer.data.model.Post
+import com.nemodream.bangkkujaengi.customer.data.model.Tag
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -51,6 +52,8 @@ class SocialMyRepository @Inject constructor(private val firestore: FirebaseFire
         val imageList = get("imageList") as? List<String> ?: emptyList()
         val savedCount = getLong("savedCount")?.toInt() ?: 0
         val commentCount = getLong("commentCount")?.toInt() ?: 0
+        val productTagPinList = get("productTagPinList") as? List<Tag> ?: emptyList()
+
 
         return Post(
             id = id,
@@ -60,7 +63,8 @@ class SocialMyRepository @Inject constructor(private val firestore: FirebaseFire
             content = content,
             imageList = imageList,
             savedCount = savedCount,
-            commentCount = commentCount
+            commentCount = commentCount,
+            productTagPinList = productTagPinList
         )
     }
 

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialRankRepository.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialRankRepository.kt
@@ -30,6 +30,7 @@ class SocialRankRepository @Inject constructor(
     // Firebase Firestore에서 게시글 데이터 가져오기
     private fun DocumentSnapshot.toPost(): Post? {
         val id = getString("id") ?: return null
+        val memberDocId = getString("memberDocId") ?: return null
         val nickname = getString("nickname") ?: return null
         val authorProfilePicture = getString("authorProfilePicture") ?: return null
         val title = getString("title") ?: return null
@@ -42,6 +43,7 @@ class SocialRankRepository @Inject constructor(
 
         return Post(
             id = id,
+            memberDocId = memberDocId,
             nickname = nickname,
             authorProfilePicture = authorProfilePicture,
             title = title,

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialRankRepository.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/data/repository/SocialRankRepository.kt
@@ -5,6 +5,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
 import com.nemodream.bangkkujaengi.customer.data.model.Member
 import com.nemodream.bangkkujaengi.customer.data.model.Post
+import com.nemodream.bangkkujaengi.customer.data.model.Tag
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -36,6 +37,8 @@ class SocialRankRepository @Inject constructor(
         val imageList = get("imageList") as? List<String> ?: emptyList()
         val savedCount = getLong("savedCount")?.toInt() ?: 0
         val commentCount = getLong("commentCount")?.toInt() ?: 0
+        val productTagPinList = get("productTagPinList") as? List<Tag> ?: emptyList()
+
 
         return Post(
             id = id,
@@ -45,7 +48,8 @@ class SocialRankRepository @Inject constructor(
             content = content,
             imageList = imageList,
             savedCount = savedCount,
-            commentCount = commentCount
+            commentCount = commentCount,
+            productTagPinList = productTagPinList
         )
     }
 }

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
@@ -11,6 +11,8 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import com.bumptech.glide.Glide
+import com.bumptech.glide.request.RequestOptions
 import com.nemodream.bangkkujaengi.R
 import com.nemodream.bangkkujaengi.customer.data.model.Post
 import com.nemodream.bangkkujaengi.customer.ui.adapter.SocialCarouselAdapter
@@ -104,18 +106,18 @@ class SocialDetailFragment : Fragment() {
 
     private fun setUpImageUI(post: Post){
         with(binding){
-
+            // 게시글 이미지 캐러셀
             val photos = post.imageList.map { imageUrl ->
                 Uri.parse(imageUrl) // String -> Uri 변환
             }
             val adapter = SocialCarouselAdapter(photos) { position, x, y ->
-                // 이미지 클릭 시 처리 로직 추가
-                Log.d("SocialDetail", "Image clicked at position $position: ($x, $y)")
             }
-
-            // ViewPager2에 어댑터 설정
             vpSocialDetailPictureCarousel.adapter = adapter
 
+            // 작성자 프로필 사진
+            Glide.with(this@SocialDetailFragment)
+                .load(post.authorProfilePicture) // URL 로드
+                .into(ivSocialDetailPostItemProfilePicture) // ImageView에 적용
         }
     }
 

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
@@ -8,11 +8,12 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ImageView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
-import com.bumptech.glide.request.RequestOptions
 import com.nemodream.bangkkujaengi.R
 import com.nemodream.bangkkujaengi.customer.data.model.Post
 import com.nemodream.bangkkujaengi.customer.ui.adapter.SocialCarouselAdapter
@@ -26,6 +27,7 @@ class SocialDetailFragment : Fragment() {
 
     private var _binding: FragmentSocialDetailBinding? = null
     private val binding get() = _binding!!
+
     private var isFollowing = false
 
     // Fragment간 통신방법 : 뷰모델 공유
@@ -45,11 +47,22 @@ class SocialDetailFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupListeners()
-        Log.d("test909","소셜 디테일 프래그먼트 실행 완료")
+
         viewModel.selectedPost.observe(viewLifecycleOwner) { post ->
+
+//             태그 해시맵 데이터를 태그 객체로 바꾸기
+//            firestore.collection("Post").document(post.id).collection("productTagPinList")
+//                .get()
+//                .addOnSuccessListener { tagMap ->
+//                    postTagPinList = tagMap?.toObjects(Tag::class.java)
+//                }
+
             setUpTextUI(post)
             setUpImageUI(post)
+            // displayTags(post)
         }
+
+
 
 //      Fragment간 통신방법 : Safe Args
 //      SocialDetailFragment에서 데이터 받기
@@ -121,6 +134,37 @@ class SocialDetailFragment : Fragment() {
         }
     }
 
+
+    private fun displayTags(post: Post) {
+        val tagPinContainer = binding.flSocialDetailTagPinOverlay
+        Log.d("TagDebug", "productTagPinList Type: ${post.productTagPinList.javaClass.name}")
+        Log.d("TagDebug", "First item: ${post.productTagPinList[0]}")
+        Log.d("TagDebug", "First item type: ${post.productTagPinList[0].javaClass.name}")
+
+        post.productTagPinList.forEach { tag ->
+
+            val x = tag.tagX!!.toFloat()
+            val y = tag.tagY!!.toFloat()
+
+            // 태그 핀 이미지 생성
+            val tagPinImageView = ImageView(requireContext()).apply {
+                setImageResource(R.drawable.ic_tag_pin)  // 태그 핀 이미지 리소스
+                layoutParams = FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.WRAP_CONTENT,
+                    FrameLayout.LayoutParams.WRAP_CONTENT
+                ).apply {
+                    leftMargin = (x - 20).toInt()
+                    topMargin = (y - 20).toInt()
+                }
+            }
+
+            // Container에 추가
+            tagPinContainer.addView(tagPinImageView)
+        }
+
+    }
+
+
     // 리스너 설정
     private fun setupListeners() {
         with(binding) {
@@ -142,9 +186,6 @@ class SocialDetailFragment : Fragment() {
 //                    // 팔로우 목록에서 멤버 제거 (나중에 구현 예정)
 //                }
             }
-
-
-
         }
     }
     private fun updateButtonState(isFollowing: Boolean) {
@@ -171,4 +212,3 @@ class SocialDetailFragment : Fragment() {
         }
     }
 }
-

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
@@ -199,6 +199,16 @@ class SocialDetailFragment : Fragment() {
             toolbarSocial.setNavigationOnClickListener {
                 findNavController().popBackStack(R.id.navigation_social, false)
             }
+
+            // 로그인한 유저와 게시글 작성자가 동일한지 확인
+            if (appContext.getUserId() == post.memberDocId) {
+                // 팔로잉 버튼을 숨김
+                btnSocialDetailFollowingFollowing.visibility = View.GONE
+            } else {
+                // 팔로잉 버튼을 보이게 설정
+                btnSocialDetailFollowingFollowing.visibility = View.VISIBLE
+            }
+
             // 초기 상태 설정 (isFollowing 여부에 따라)
             updateButtonState(isFollowing)
 

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
@@ -8,19 +8,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.setFragmentResultListener
-import androidx.lifecycle.Observer
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import androidx.recyclerview.widget.LinearLayoutManager
 import com.nemodream.bangkkujaengi.R
-import com.nemodream.bangkkujaengi.customer.data.model.Member
 import com.nemodream.bangkkujaengi.customer.data.model.Post
-import com.nemodream.bangkkujaengi.customer.data.model.Product
-import com.nemodream.bangkkujaengi.customer.data.model.Tag
+import com.nemodream.bangkkujaengi.customer.ui.viewmodel.SocialDiscoveryViewModel
 import com.nemodream.bangkkujaengi.databinding.FragmentSocialDetailBinding
-import com.nemodream.bangkkujaengi.utils.loadImage
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.ArrayList
+import kotlin.getValue
 
 @AndroidEntryPoint
 class SocialDetailFragment : Fragment() {
@@ -30,11 +26,8 @@ class SocialDetailFragment : Fragment() {
     private val binding get() = _binding!!
     private var isFollowing = false
 
-    // private val viewModel: SocialFollowingAllViewModel by viewModels()
-
-    // 팔로잉 프로필 RecyclerView의 어댑터
-    // private val socialFollowingAllAdapter = SocialFollowingAllAdapter()
-
+    // Fragment간 통신방법 : 뷰모델 공유
+    private val viewModel: SocialDiscoveryViewModel by activityViewModels()
 
     // 프래그먼트의 뷰를 생성하는 메서드
     override fun onCreateView(
@@ -50,6 +43,11 @@ class SocialDetailFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupListeners()
+        Log.d("test909","소셜 디테일 프래그먼트 실행 완료")
+        viewModel.selectedPost.observe(viewLifecycleOwner) { post ->
+            setUpTextUI(post)
+            setUpImageUI(post)
+        }
 
 //      Fragment간 통신방법 : Safe Args
 //      SocialDetailFragment에서 데이터 받기
@@ -93,9 +91,20 @@ class SocialDetailFragment : Fragment() {
         _binding = null
     }
 
-    private fun setUpUI(post: Post){
+    private fun setUpTextUI(post: Post){
         with(binding){
             tvSocialDetailContent.text = post.content
+            tvSocialDetailLikeCount.text = post.savedCount.toString()
+            tvSocialDetailCommentCount.text = post.commentCount.toString()
+            tvSocialDetailPostItemTitle.text = post.title
+            tvSocialDetailContent.text = post.content
+            tvSocialDetailPostItemNickname.text = post.nickname
+        }
+    }
+
+    private fun setUpImageUI(post: Post){
+        with(binding){
+
         }
     }
 
@@ -110,7 +119,7 @@ class SocialDetailFragment : Fragment() {
             updateButtonState(isFollowing)
 
             // 버튼 클릭 리스너
-            btnFollowingFollowing.setOnClickListener {
+            btnSocialDetailFollowingFollowing.setOnClickListener {
                 isFollowing = !isFollowing
                 updateButtonState(isFollowing)
 
@@ -127,25 +136,25 @@ class SocialDetailFragment : Fragment() {
     }
     private fun updateButtonState(isFollowing: Boolean) {
         if (isFollowing) {
-            binding.btnFollowingFollowing.text = "팔로잉"
-            binding.btnFollowingFollowing.setTextColor(Color.parseColor("#58443B")) // 글자색
-            binding.btnFollowingFollowing.setBackgroundTintList(
+            binding.btnSocialDetailFollowingFollowing.text = "팔로잉"
+            binding.btnSocialDetailFollowingFollowing.setTextColor(Color.parseColor("#58443B")) // 글자색
+            binding.btnSocialDetailFollowingFollowing.setBackgroundTintList(
                 ColorStateList.valueOf(Color.parseColor("#DFDFDF")) // 버튼 배경색
             )
-            binding.btnFollowingFollowing.strokeColor =
+            binding.btnSocialDetailFollowingFollowing.strokeColor =
                 ColorStateList.valueOf(Color.parseColor("#818080")) // 테두리 색상
-            binding.btnFollowingFollowing.strokeWidth = 1 // 테두리 두께 (px 단위)
-            binding.btnFollowingFollowing.setPadding(0,0,0,0)
+            binding.btnSocialDetailFollowingFollowing.strokeWidth = 1 // 테두리 두께 (px 단위)
+            binding.btnSocialDetailFollowingFollowing.setPadding(0,0,0,0)
         } else {
-            binding.btnFollowingFollowing.text = "팔로우"
-            binding.btnFollowingFollowing.setTextColor(Color.parseColor("#FFFFFF")) // 글자색
-            binding.btnFollowingFollowing.setBackgroundTintList(
+            binding.btnSocialDetailFollowingFollowing.text = "팔로우"
+            binding.btnSocialDetailFollowingFollowing.setTextColor(Color.parseColor("#FFFFFF")) // 글자색
+            binding.btnSocialDetailFollowingFollowing.setBackgroundTintList(
                 ColorStateList.valueOf(Color.parseColor("#332828")) // 버튼 배경색
             )
-            binding.btnFollowingFollowing.strokeColor =
+            binding.btnSocialDetailFollowingFollowing.strokeColor =
                 ColorStateList.valueOf(Color.parseColor("#000000")) // 테두리 색상 (기본값, 변경 가능)
-            binding.btnFollowingFollowing.strokeWidth = 1 // 테두리 두께 (px 단위)
-            binding.btnFollowingFollowing.setPadding(0,0,0,0)
+            binding.btnSocialDetailFollowingFollowing.strokeWidth = 1 // 테두리 두께 (px 단위)
+            binding.btnSocialDetailFollowingFollowing.setPadding(0,0,0,0)
         }
     }
 }

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
@@ -51,32 +51,40 @@ class SocialDetailFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         setupListeners()
 
-        setFragmentResultListener("clickedPost") { clickedPost, bundle ->
-            val clickedId = bundle.getString("id")
-            val clickedNickname = bundle.getString("nickname")
-            val clickedAuthorProfilePicture = bundle.getString("authorProfilePicture")
-            val clickedTitle = bundle.getString("title")
-            val clickedContent = bundle.getString("content")
-            val clickedImageList = bundle.getStringArrayList("imageList")
-            val clickedSavedCount = bundle.getInt("savedCount")
-            val clickedCommentCount = bundle.getInt("commentCount")
+//      Fragment간 통신방법 : Safe Args
+//      SocialDetailFragment에서 데이터 받기
+//        val post = arguments?.let { SocialDetailFragmentArgs.fromBundle(it).post }
+//        post?.let { setUpUI(it) }
+//        Log.d("test909", "소셜 디테일 프래그먼트 : ${post}")
 
-            // Post 객체 생성
-            val post = Post(
-                id = clickedId.orEmpty(),
-                nickname = clickedNickname.orEmpty(),
-                authorProfilePicture = clickedAuthorProfilePicture.orEmpty(),
-                title = clickedTitle.orEmpty(),
-                content = clickedContent.orEmpty(),
-                imageList = clickedImageList?.toList() ?: emptyList(),
-                productTagPinList = emptyList(),
-                savedCount = clickedSavedCount,
-                commentCount = clickedCommentCount
-            )
-
-            Log.d("test909", "소셜 디테일 프래그먼트 : ${post}")
-            setUpUI(post)
-        }
+//        Fragment Manager 통신 방법 : Fragment Manager 사용
+//        setFragmentResult는 같은 FragmentManager 내에서만 동작하므로 Navigation으로 이동 시 사용 불가능
+//        setFragmentResultListener("clickedPost") { clickedPost, bundle ->
+//            val clickedId = bundle.getString("id")
+//            val clickedNickname = bundle.getString("nickname")
+//            val clickedAuthorProfilePicture = bundle.getString("authorProfilePicture")
+//            val clickedTitle = bundle.getString("title")
+//            val clickedContent = bundle.getString("content")
+//            val clickedImageList = bundle.getStringArrayList("imageList")
+//            val clickedSavedCount = bundle.getInt("savedCount")
+//            val clickedCommentCount = bundle.getInt("commentCount")
+//
+//            // Post 객체 생성
+//            val post = Post(
+//                id = clickedId.orEmpty(),
+//                nickname = clickedNickname.orEmpty(),
+//                authorProfilePicture = clickedAuthorProfilePicture.orEmpty(),
+//                title = clickedTitle.orEmpty(),
+//                content = clickedContent.orEmpty(),
+//                imageList = clickedImageList?.toList() ?: emptyList(),
+//                productTagPinList = emptyList(),
+//                savedCount = clickedSavedCount,
+//                commentCount = clickedCommentCount
+//            )
+//
+//            Log.d("test909", "소셜 디테일 프래그먼트 : ${post}")
+//            setUpUI(post)
+//        }
     }
 
     // 프래그먼트가 파괴될 때 Binding 해제

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
@@ -3,21 +3,28 @@ package com.nemodream.bangkkujaengi.customer.ui.fragment
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.nemodream.bangkkujaengi.R
 import com.nemodream.bangkkujaengi.customer.data.model.Member
+import com.nemodream.bangkkujaengi.customer.data.model.Post
+import com.nemodream.bangkkujaengi.customer.data.model.Product
+import com.nemodream.bangkkujaengi.customer.data.model.Tag
 import com.nemodream.bangkkujaengi.databinding.FragmentSocialDetailBinding
 import com.nemodream.bangkkujaengi.utils.loadImage
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.ArrayList
 
 @AndroidEntryPoint
 class SocialDetailFragment : Fragment() {
+
 
     private var _binding: FragmentSocialDetailBinding? = null
     private val binding get() = _binding!!
@@ -43,12 +50,45 @@ class SocialDetailFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupListeners()
+
+        setFragmentResultListener("clickedPost") { clickedPost, bundle ->
+            val clickedId = bundle.getString("id")
+            val clickedNickname = bundle.getString("nickname")
+            val clickedAuthorProfilePicture = bundle.getString("authorProfilePicture")
+            val clickedTitle = bundle.getString("title")
+            val clickedContent = bundle.getString("content")
+            val clickedImageList = bundle.getStringArrayList("imageList")
+            val clickedSavedCount = bundle.getInt("savedCount")
+            val clickedCommentCount = bundle.getInt("commentCount")
+
+            // Post 객체 생성
+            val post = Post(
+                id = clickedId.orEmpty(),
+                nickname = clickedNickname.orEmpty(),
+                authorProfilePicture = clickedAuthorProfilePicture.orEmpty(),
+                title = clickedTitle.orEmpty(),
+                content = clickedContent.orEmpty(),
+                imageList = clickedImageList?.toList() ?: emptyList(),
+                productTagPinList = emptyList(),
+                savedCount = clickedSavedCount,
+                commentCount = clickedCommentCount
+            )
+
+            Log.d("test909", "소셜 디테일 프래그먼트 : ${post}")
+            setUpUI(post)
+        }
     }
 
     // 프래그먼트가 파괴될 때 Binding 해제
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun setUpUI(post: Post){
+        with(binding){
+            tvSocialDetailContent.text = post.content
+        }
     }
 
     // 리스너 설정

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
@@ -19,6 +19,7 @@ import com.bumptech.glide.Glide
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.nemodream.bangkkujaengi.R
+import com.nemodream.bangkkujaengi.customer.data.model.Member
 import com.nemodream.bangkkujaengi.customer.data.model.Post
 import com.nemodream.bangkkujaengi.customer.ui.adapter.SocialCarouselAdapter
 import com.nemodream.bangkkujaengi.customer.ui.viewmodel.SocialDiscoveryViewModel
@@ -66,19 +67,30 @@ class SocialDetailFragment : Fragment() {
 
         viewModel.selectedPost.observe(viewLifecycleOwner) { post ->
 
+            // 현재 사용자의 팔로잉 목록을 가져와서 작성자 ID가 있는지 확인
+                firestore.collection("Member").document(appContext.getUserId())
+                    .get()
+                    .addOnSuccessListener { documentSnapshot ->
+                    val currentUser = documentSnapshot.toObject(Member::class.java)
+                    val followingList = currentUser?.followingList ?: emptyList()
+
+                    // 팔로잉 목록에 게시글 작성자의 memberDocId가 있으면 isFollowing을 true로 설정
+                    isFollowing = followingList.any { it.id == post.memberDocId }
+                    updateButtonState(isFollowing)
+                }
+
 //             태그 해시맵 데이터를 태그 객체로 바꾸기
 //            firestore.collection("Post").document(post.id).collection("productTagPinList")
 //                .get()
 //                .addOnSuccessListener { tagMap ->
 //                    postTagPinList = tagMap?.toObjects(Tag::class.java)
 //                }
+
             setupListeners(post)
             setUpTextUI(post)
             setUpImageUI(post)
             // displayTags(post)
         }
-
-
 
 //      Fragment간 통신방법 : Safe Args
 //      SocialDetailFragment에서 데이터 받기
@@ -132,6 +144,7 @@ class SocialDetailFragment : Fragment() {
             tvSocialDetailPostItemNickname.text = post.nickname
         }
     }
+
 
     private fun setUpImageUI(post: Post){
         with(binding){
@@ -223,6 +236,9 @@ class SocialDetailFragment : Fragment() {
             }
         }
     }
+
+
+    // 팔로잉 토글 효과
     private fun updateButtonState(isFollowing: Boolean) {
         if (isFollowing) {
             binding.btnSocialDetailFollowingFollowing.text = "팔로잉"

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDetailFragment.kt
@@ -2,6 +2,7 @@ package com.nemodream.bangkkujaengi.customer.ui.fragment
 
 import android.content.res.ColorStateList
 import android.graphics.Color
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -9,10 +10,10 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.nemodream.bangkkujaengi.R
 import com.nemodream.bangkkujaengi.customer.data.model.Post
+import com.nemodream.bangkkujaengi.customer.ui.adapter.SocialCarouselAdapter
 import com.nemodream.bangkkujaengi.customer.ui.viewmodel.SocialDiscoveryViewModel
 import com.nemodream.bangkkujaengi.databinding.FragmentSocialDetailBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -20,7 +21,6 @@ import kotlin.getValue
 
 @AndroidEntryPoint
 class SocialDetailFragment : Fragment() {
-
 
     private var _binding: FragmentSocialDetailBinding? = null
     private val binding get() = _binding!!
@@ -104,6 +104,17 @@ class SocialDetailFragment : Fragment() {
 
     private fun setUpImageUI(post: Post){
         with(binding){
+
+            val photos = post.imageList.map { imageUrl ->
+                Uri.parse(imageUrl) // String -> Uri 변환
+            }
+            val adapter = SocialCarouselAdapter(photos) { position, x, y ->
+                // 이미지 클릭 시 처리 로직 추가
+                Log.d("SocialDetail", "Image clicked at position $position: ($x, $y)")
+            }
+
+            // ViewPager2에 어댑터 설정
+            vpSocialDetailPictureCarousel.adapter = adapter
 
         }
     }

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDiscoveryFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDiscoveryFragment.kt
@@ -78,22 +78,24 @@ class SocialDiscoveryFragment : Fragment(), OnPostItemClickListener {
     override fun onPostItemClick(post: Post) {
         Log.d("SocialDiscoveryFragment", "Post clicked: ${post}")
 
-        val clickedPost = Bundle().apply {
-            putString("id", post.id)
-            putString("nickname", post.id)
-            putString("authorProfilePicture", post.authorProfilePicture)
-            putString("title", post.title)
-            putString("content", post.content)
-            putStringArrayList("imageList", post.imageList as ArrayList<String?>?)
-            // putStringArrayList("productTagPinList", post.productTagPinList as ArrayList<String?>?)
-            putInt("savedCount", post.savedCount)
-            putInt("commentCount", post.commentCount)
-        }
+//        Fragment간 통신방법 : Fragment Manager 사용
+//        setFragmentResult는 같은 FragmentManager 내에서만 동작하므로 Navigation으로 이동 시 사용 불가능
+//        val clickedPost = Bundle().apply {
+//            putString("id", post.id)
+//            putString("nickname", post.id)
+//            putString("authorProfilePicture", post.authorProfilePicture)
+//            putString("title", post.title)
+//            putString("content", post.content)
+//            putStringArrayList("imageList", post.imageList as ArrayList<String?>?)
+//            // putStringArrayList("productTagPinList", post.productTagPinList as ArrayList<String?>?)
+//            putInt("savedCount", post.savedCount)
+//            putInt("commentCount", post.commentCount)
+//        }
+//        Log.d("test909","소셜 디스커버리 프래그먼트 : ${clickedPost}")
+//        setFragmentResult("clickedPost", clickedPost)
 
-        Log.d("test909","소셜 디스커버리 프래그먼트 : ${clickedPost}")
-
-        setFragmentResult("clickedPost", clickedPost)
-
+        // Fragment간 통신방법 : Safe Args 사용
+        // SocialDiscoveryFragment에서 Safe Args로 데이터 전달
         val action = SocialFragmentDirections.actionSocialFragmentToSocialDetailFragment()
         findNavController().navigate(action)
     }

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDiscoveryFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDiscoveryFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
@@ -16,6 +17,7 @@ import com.nemodream.bangkkujaengi.customer.ui.adapter.SocialDiscoveryAdapter
 import com.nemodream.bangkkujaengi.customer.ui.viewmodel.SocialDiscoveryViewModel
 import com.nemodream.bangkkujaengi.databinding.FragmentSocialDiscoveryBinding
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.ArrayList
 
 @AndroidEntryPoint
 class SocialDiscoveryFragment : Fragment(), OnPostItemClickListener {
@@ -74,7 +76,24 @@ class SocialDiscoveryFragment : Fragment(), OnPostItemClickListener {
      * 게시글 클릭 이벤트 처리
      */
     override fun onPostItemClick(post: Post) {
-        Log.d("SocialDiscoveryFragment", "Post clicked: ${post.title}")
+        Log.d("SocialDiscoveryFragment", "Post clicked: ${post}")
+
+        val clickedPost = Bundle().apply {
+            putString("id", post.id)
+            putString("nickname", post.id)
+            putString("authorProfilePicture", post.authorProfilePicture)
+            putString("title", post.title)
+            putString("content", post.content)
+            putStringArrayList("imageList", post.imageList as ArrayList<String?>?)
+            // putStringArrayList("productTagPinList", post.productTagPinList as ArrayList<String?>?)
+            putInt("savedCount", post.savedCount)
+            putInt("commentCount", post.commentCount)
+        }
+
+        Log.d("test909","소셜 디스커버리 프래그먼트 : ${clickedPost}")
+
+        setFragmentResult("clickedPost", clickedPost)
+
         val action = SocialFragmentDirections.actionSocialFragmentToSocialDetailFragment()
         findNavController().navigate(action)
     }

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDiscoveryFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialDiscoveryFragment.kt
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
@@ -17,7 +17,6 @@ import com.nemodream.bangkkujaengi.customer.ui.adapter.SocialDiscoveryAdapter
 import com.nemodream.bangkkujaengi.customer.ui.viewmodel.SocialDiscoveryViewModel
 import com.nemodream.bangkkujaengi.databinding.FragmentSocialDiscoveryBinding
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.ArrayList
 
 @AndroidEntryPoint
 class SocialDiscoveryFragment : Fragment(), OnPostItemClickListener {
@@ -25,7 +24,7 @@ class SocialDiscoveryFragment : Fragment(), OnPostItemClickListener {
     private var _binding: FragmentSocialDiscoveryBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: SocialDiscoveryViewModel by viewModels()
+    private val viewModel: SocialDiscoveryViewModel by activityViewModels()
 
     private val socialDiscoveryAdapter: SocialDiscoveryAdapter by lazy {
         SocialDiscoveryAdapter(this)
@@ -96,6 +95,10 @@ class SocialDiscoveryFragment : Fragment(), OnPostItemClickListener {
 
         // Fragment간 통신방법 : Safe Args 사용
         // SocialDiscoveryFragment에서 Safe Args로 데이터 전달
+
+        // Fragment간 통신방법 : 뷰모델 공유
+        viewModel.selectedPost.value = post
+        Log.d("test909","소셜 디스커버리 프래그먼트 : ${viewModel.selectedPost.value}")
         val action = SocialFragmentDirections.actionSocialFragmentToSocialDetailFragment()
         findNavController().navigate(action)
     }

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialFollowingFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialFollowingFragment.kt
@@ -112,7 +112,7 @@ class SocialFollowingFragment : Fragment(), OnPostItemClickListener {
                 binding.ivSelectedProfileImage.loadImage(selectedMember.memberProfileImage.toString())
                 binding.tvSelectedProfileNickname.text = it.memberNickName
                 binding.tvSelectedProfileFollowInfo.text =
-                    "팔로잉 ${selectedMember.followingCount}명     팔로워 ${selectedMember.followerCount}명"
+                    "팔로잉 ${selectedMember.followingList.size}명     팔로워 ${selectedMember.followerCount}명"
             } ?: run {
                 // 선택된 멤버가 없을 경우 프로필 정보를 숨김
                 binding.clSelectedProfileInfo.visibility = View.GONE
@@ -170,7 +170,7 @@ class SocialFollowingFragment : Fragment(), OnPostItemClickListener {
         with(binding) {
             // 팔로잉 상태 토글
             btnFollowingFollowing.setOnClickListener {
-                viewModel.toggleFollowing()
+                viewModel.toggleFollowing(appContext.getUserId())
             }
 
             tvAllProfiles.setOnClickListener {

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialFollowingFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialFollowingFragment.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
@@ -18,11 +19,13 @@ import com.nemodream.bangkkujaengi.customer.data.repository.SocialFollowingRepos
 import com.nemodream.bangkkujaengi.customer.ui.adapter.OnPostItemClickListener
 import com.nemodream.bangkkujaengi.customer.ui.adapter.SocialDiscoveryAdapter
 import com.nemodream.bangkkujaengi.customer.ui.adapter.SocialFollowingProfilesAdapter
+import com.nemodream.bangkkujaengi.customer.ui.viewmodel.SocialDiscoveryViewModel
 import com.nemodream.bangkkujaengi.customer.ui.viewmodel.SocialFollowingViewModel
 import com.nemodream.bangkkujaengi.databinding.FragmentSocialFollowingBinding
 import com.nemodream.bangkkujaengi.utils.getUserId
 import com.nemodream.bangkkujaengi.utils.loadImage
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.getValue
 
 @AndroidEntryPoint
 class SocialFollowingFragment : Fragment(), OnPostItemClickListener {
@@ -32,6 +35,7 @@ class SocialFollowingFragment : Fragment(), OnPostItemClickListener {
     private lateinit var appContext: Context
 
     private val viewModel: SocialFollowingViewModel by viewModels()
+    private val shareViewModel: SocialDiscoveryViewModel by activityViewModels()
 
     // 팔로잉 프로필 RecyclerView의 어댑터
     private val profileAdapter: SocialFollowingProfilesAdapter by lazy {
@@ -179,6 +183,7 @@ class SocialFollowingFragment : Fragment(), OnPostItemClickListener {
 
     //게시글 클릭 이벤트를 처리하는 메서드
     override fun onPostItemClick(post: Post) {
+        shareViewModel.selectedPost.value = post
         val action = SocialFragmentDirections.actionSocialFragmentToSocialDetailFragment()
         findNavController().navigate(action)
     }

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialMyFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialMyFragment.kt
@@ -168,7 +168,7 @@ class SocialMyFragment : Fragment(), OnPostItemClickListener {
                     ivMyProfileImage.loadImage(profile.memberProfileImage.toString())
                 } ?: ivMyProfileImage.setImageResource(R.drawable.ic_default_profile)
                 tvMyProfileNickname.text = "${profile.memberNickName}"
-                tvMyProfileFollowInfo.text = "팔로잉 ${profile.followingCount}명   팔로워 ${profile.followerCount}명"
+                tvMyProfileFollowInfo.text = "팔로잉 ${profile.followingList.size}명   팔로워 ${profile.followerCount}명"
             }
         })
 

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialMyFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialMyFragment.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
@@ -17,11 +18,13 @@ import com.nemodream.bangkkujaengi.customer.data.model.Post
 import com.nemodream.bangkkujaengi.customer.data.model.SocialLogin
 import com.nemodream.bangkkujaengi.customer.ui.adapter.OnPostItemClickListener
 import com.nemodream.bangkkujaengi.customer.ui.adapter.SocialDiscoveryAdapter
+import com.nemodream.bangkkujaengi.customer.ui.viewmodel.SocialDiscoveryViewModel
 import com.nemodream.bangkkujaengi.customer.ui.viewmodel.SocialMyViewModel
 import com.nemodream.bangkkujaengi.databinding.FragmentSocialMyBinding
 import com.nemodream.bangkkujaengi.utils.getUserId
 import com.nemodream.bangkkujaengi.utils.loadImage
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.getValue
 
 @AndroidEntryPoint
 class SocialMyFragment : Fragment(), OnPostItemClickListener {
@@ -31,6 +34,7 @@ class SocialMyFragment : Fragment(), OnPostItemClickListener {
     private lateinit var appContext: Context
 
     private val viewModel: SocialMyViewModel by viewModels()
+    private val shareViewModel: SocialDiscoveryViewModel by activityViewModels()
     private val socialMyAdapter: SocialDiscoveryAdapter by lazy { SocialDiscoveryAdapter(this) }
 
     private var isMyPostsSelected: Boolean = true
@@ -194,6 +198,7 @@ class SocialMyFragment : Fragment(), OnPostItemClickListener {
      * 게시글 클릭 이벤트 처리
      */
     override fun onPostItemClick(post: Post) {
+        shareViewModel.selectedPost.value = post
         val action = SocialFragmentDirections.actionSocialFragmentToSocialDetailFragment()
         findNavController().navigate(action)
     }

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialRankFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialRankFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
@@ -12,9 +13,11 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.nemodream.bangkkujaengi.customer.data.model.Post
 import com.nemodream.bangkkujaengi.customer.ui.adapter.OnPostItemClickListener
 import com.nemodream.bangkkujaengi.customer.ui.adapter.SocialDiscoveryAdapter
+import com.nemodream.bangkkujaengi.customer.ui.viewmodel.SocialDiscoveryViewModel
 import com.nemodream.bangkkujaengi.customer.ui.viewmodel.SocialRankViewModel
 import com.nemodream.bangkkujaengi.databinding.FragmentSocialRankBinding
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.getValue
 
 @AndroidEntryPoint
 class SocialRankFragment : Fragment(), OnPostItemClickListener {
@@ -23,6 +26,7 @@ class SocialRankFragment : Fragment(), OnPostItemClickListener {
     private val binding get() = _binding!!
 
     private val viewModel: SocialRankViewModel by viewModels()
+    private val shareViewModel: SocialDiscoveryViewModel by activityViewModels()
 
     private val socialRankAdapter: SocialDiscoveryAdapter by lazy {
         SocialDiscoveryAdapter(this)
@@ -81,6 +85,7 @@ class SocialRankFragment : Fragment(), OnPostItemClickListener {
      * 게시글 클릭 이벤트 처리
      */
     override fun onPostItemClick(post: Post) {
+        shareViewModel.selectedPost.value = post
         val action = SocialFragmentDirections.actionSocialFragmentToSocialDetailFragment()
         findNavController().navigate(action)
     }

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialWritePictureFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialWritePictureFragment.kt
@@ -1,10 +1,8 @@
 package com.nemodream.bangkkujaengi.customer.ui.fragment
 
-import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
-import android.os.Environment
 import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -27,9 +25,6 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
 import com.nemodream.bangkkujaengi.customer.data.model.Post
 import com.nemodream.bangkkujaengi.utils.getUserId
-import java.io.File
-import java.io.FileOutputStream
-import java.io.InputStream
 
 
 class SocialWritePictureFragment : Fragment() {

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialWritePictureFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialWritePictureFragment.kt
@@ -244,6 +244,7 @@ class SocialWritePictureFragment : Fragment() {
                             // Post 객체 생성
                             val post = Post(
                                 id = firestore.collection("posts").document().id, // 자동 생성된 ID
+                                memberDocId = appContext.getUserId(),
                                 nickname = memberNickName ?: "익명", // 닉네임 없으면 "익명" 처리
                                 authorProfilePicture = memberProfileImage
                                     ?: "", // 프로필 이미지 없으면 빈 문자열 처리

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialWritePictureFragment.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/fragment/SocialWritePictureFragment.kt
@@ -24,6 +24,7 @@ import com.nemodream.bangkkujaengi.customer.ui.adapter.SocialCarouselAdapter
 import com.nemodream.bangkkujaengi.databinding.FragmentSocialWritePictureBinding
 import com.nemodream.bangkkujaengi.databinding.ItemSocialTagProductLabelBinding
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.storage.FirebaseStorage
 import com.nemodream.bangkkujaengi.customer.data.model.Post
 import com.nemodream.bangkkujaengi.utils.getUserId
 import java.io.File
@@ -145,27 +146,7 @@ class SocialWritePictureFragment : Fragment() {
         setupTagAndLabelListeners(tagPin, labelBinding, container, position, x, y)
     }
 
-    // 이미지 경로 설정하는 함수
-    fun saveImageToStorage(context: Context, imageUri: Uri): String? {
-        val resolver: ContentResolver = context.contentResolver
-        val fileName = "IMG_${System.currentTimeMillis()}.jpg"
-        val storageDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
-        val imageFile = File(storageDir, fileName)
 
-        return try {
-            val inputStream: InputStream? = resolver.openInputStream(imageUri)
-            val outputStream = FileOutputStream(imageFile)
-
-            inputStream?.copyTo(outputStream)
-            inputStream?.close()
-            outputStream.close()
-
-            imageFile.absolutePath // 저장된 파일의 경로 반환
-        } catch (e: Exception) {
-            e.printStackTrace()
-            null
-        }
-    }
 
     // Firestore에서 memberNickName 필드를 가져오는 함수
     fun getMemberNickName(userId: String, callback: (String?) -> Unit) {
@@ -181,6 +162,46 @@ class SocialWritePictureFragment : Fragment() {
             .document(userId)
             .get()
             .addOnSuccessListener { callback(it.getString("memberProfileImage")) }
+    }
+
+    // 이미지를 로컬저장소에서 Firebase Storage에 업로드
+    // 업로드가 완료되면 해당 이미지의 다운로드 URL을 반환
+    fun uploadImageToFirebaseStorage(context: Context, imageUri: Uri, callback: (String?) -> Unit) {
+        val storage = FirebaseStorage.getInstance()
+        val storageRef = storage.reference
+        val imageRef = storageRef.child("images/${System.currentTimeMillis()}.jpg")
+
+        val uploadTask = imageRef.putFile(imageUri)
+        uploadTask.addOnSuccessListener { taskSnapshot ->
+            // 업로드 성공 후, 다운로드 URL 가져오기
+            imageRef.downloadUrl.addOnSuccessListener { uri ->
+                callback(uri.toString())  // 이미지 URL 반환
+            }
+        }.addOnFailureListener { e ->
+            e.printStackTrace()
+            callback(null)  // 실패 시 null 반환
+        }
+    }
+
+    // 업로드된 이미지의 URL을 Firestore에 저장
+    // Firestore에 게시글을 저장할 때, 각 이미지를 Firebase Storage에 업로드하고 그 URL을 imageList에 저장
+    fun uploadImagesAndCreatePost(selectedPhotos: List<Uri>, callback: (List<String>) -> Unit) {
+        val imageUrls = mutableListOf<String>()
+        var uploadCount = 0
+
+        selectedPhotos.forEach { imageUri ->
+            uploadImageToFirebaseStorage(appContext, imageUri) { imageUrl ->
+                if (imageUrl != null) {
+                    imageUrls.add(imageUrl)
+                }
+                uploadCount++
+
+                // 모든 이미지가 업로드된 후에 콜백 호출
+                if (uploadCount == selectedPhotos.size) {
+                    callback(imageUrls)
+                }
+            }
+        }
     }
 
     // 리스너 모음
@@ -220,33 +241,40 @@ class SocialWritePictureFragment : Fragment() {
                     return@setOnClickListener
                 }
 
-                // Firestore에서 memberNickName 가져오기
-                getMemberNickName(appContext.getUserId()) { memberNickName ->
-                    getMemberProfileImage(appContext.getUserId()) { memberProfileImage ->
-                        // Post 객체 생성
-                        val post = Post(
-                            id = firestore.collection("posts").document().id, // 자동 생성된 ID
-                            nickname = memberNickName ?: "익명", // 닉네임 없으면 "익명" 처리
-                            authorProfilePicture = memberProfileImage ?: "", // 프로필 이미지 없으면 빈 문자열 처리
-                            title = title,
-                            content = content,
-                            imageList = selectedPhotos.mapNotNull { saveImageToStorage(appContext, it) }, // 이미지 Uri를 문자열로 변환
-                            productTagPinList = productTagPinList,
-                            savedCount = 0, // 초기값
-                            commentCount = 0 // 초기값
-                        )
+                // 이미지 업로드 후 Firestore에 게시글 저장
+                uploadImagesAndCreatePost(selectedPhotos) { imageUrls ->
+                    // Firestore에서 memberNickName 가져오기
+                    getMemberNickName(appContext.getUserId()) { memberNickName ->
+                        getMemberProfileImage(appContext.getUserId()) { memberProfileImage ->
+                            // Post 객체 생성
+                            val post = Post(
+                                id = firestore.collection("posts").document().id, // 자동 생성된 ID
+                                nickname = memberNickName ?: "익명", // 닉네임 없으면 "익명" 처리
+                                authorProfilePicture = memberProfileImage
+                                    ?: "", // 프로필 이미지 없으면 빈 문자열 처리
+                                title = title,
+                                content = content,
+                                imageList = imageUrls, // 이미지 Uri를 문자열로 변환
+                                productTagPinList = productTagPinList,
+                                savedCount = 0, // 초기값
+                                commentCount = 0 // 초기값
+                            )
 
-                        // Firestore에 게시글 저장
-                        firestore.collection("Post")
-                            .document(post.id)
-                            .set(post)
-                            .addOnSuccessListener {
-                                Toast.makeText(context, "게시글이 성공적으로 작성되었습니다.", Toast.LENGTH_SHORT).show()
-                                findNavController().popBackStack() // 게시글 작성 후 이전 화면으로 돌아가기
-                            }
-                            .addOnFailureListener { e ->
-                                Toast.makeText(context, "게시글 작성에 실패했습니다: ${e.message}", Toast.LENGTH_SHORT).show()
-                            }
+                            // Firestore에 게시글 저장
+                            firestore.collection("Post")
+                                .document(post.id)
+                                .set(post)
+                                .addOnSuccessListener {
+                                    findNavController().popBackStack() // 게시글 작성 후 이전 화면으로 돌아가기
+                                }
+                                .addOnFailureListener { e ->
+                                    Toast.makeText(
+                                        context,
+                                        "게시글 작성에 실패했습니다: ${e.message}",
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/viewmodel/SocialDiscoveryViewModel.kt
+++ b/app/src/main/java/com/nemodream/bangkkujaengi/customer/ui/viewmodel/SocialDiscoveryViewModel.kt
@@ -19,6 +19,9 @@ class SocialDiscoveryViewModel @Inject constructor(
     private val _posts = MutableLiveData<List<Post>>(emptyList())
     val posts: LiveData<List<Post>> get() = _posts
 
+    // SocialDetailFragment 와 공유할 뷰모델
+    val selectedPost = MutableLiveData<Post>()
+
     /**
      * 게시글 목록 로드
      */

--- a/app/src/main/res/layout/fragment_social_detail.xml
+++ b/app/src/main/res/layout/fragment_social_detail.xml
@@ -47,9 +47,9 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <!-- 이미지 -->
+    <!-- 게시글 이미지 뷰페이저 -->
     <FrameLayout
-        android:id="@+id/fl_social_write_picture_container"
+        android:id="@+id/fl_social_detail_picture_container"
         android:layout_width="360dp"
         android:layout_height="473dp"
         android:layout_marginTop="20dp"
@@ -61,7 +61,7 @@
 
         <!-- 이미지 ViewPager2 -->
         <androidx.viewpager2.widget.ViewPager2
-            android:id="@+id/vp_social_write_picture_carousel"
+            android:id="@+id/vp_social_detail_picture_carousel"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             tools:listitem="@layout/item_social_carousel_photo"
@@ -69,7 +69,7 @@
 
         <!-- 태그 핀 FrameLayout -->
         <FrameLayout
-            android:id="@+id/fl_tag_pin_overlay"
+            android:id="@+id/fl__social_detail_tag_pin_overlay"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
     </FrameLayout>
@@ -77,19 +77,19 @@
 
     <!-- 좋아요와 댓글 아이콘 -->
     <LinearLayout
-        android:id="@+id/layout_like_and_comment"
+        android:id="@+id/layout__social_detail_like_and_comment"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:layout_marginTop="10dp"
         android:layout_marginStart="27dp"
-        app:layout_constraintTop_toBottomOf="@id/fl_social_write_picture_container"
+        app:layout_constraintTop_toBottomOf="@id/fl_social_detail_picture_container"
         app:layout_constraintStart_toStartOf="parent"
         >
 
         <!-- 좋아요 이미지 -->
         <ImageView
-            android:id="@+id/ic_like"
+            android:id="@+id/ic__social_detail_like"
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_marginEnd="8dp"
@@ -98,7 +98,7 @@
 
         <!-- 좋아요 -->
         <TextView
-            android:id="@+id/tv_like_count"
+            android:id="@+id/tv__social_detail_like_count"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="999"
@@ -107,7 +107,7 @@
 
         <!-- 댓글 이미지 -->
         <ImageView
-            android:id="@+id/ic_comment"
+            android:id="@+id/ic__social_detail_comment"
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_marginStart="16dp"
@@ -118,7 +118,7 @@
 
         <!-- 댓글 -->
         <TextView
-            android:id="@+id/tv_comment_count"
+            android:id="@+id/tv_social_detail_comment_count"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="2"
@@ -128,18 +128,18 @@
 
     <!-- 게시글 제목과 작성자 정보 -->
     <LinearLayout
-        android:id="@+id/layout_title_and_author"
+        android:id="@+id/layout_social_detail_title_and_author"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:layout_marginTop="10dp"
         android:layout_marginStart="25dp"
-        app:layout_constraintTop_toBottomOf="@id/layout_like_and_comment"
+        app:layout_constraintTop_toBottomOf="@id/layout__social_detail_like_and_comment"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
         <TextView
-            android:id="@+id/tv_social_post_item_title"
+            android:id="@+id/tv_social_detail_post_item_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
@@ -155,14 +155,14 @@
             android:layout_marginTop="8dp">
 
             <com.google.android.material.imageview.ShapeableImageView
-                android:id="@+id/iv_social_post_item_profile_picture"
+                android:id="@+id/iv_social_detail_post_item_profile_picture"
                 android:layout_width="30dp"
                 android:layout_height="30dp"
                 app:shapeAppearanceOverlay="@style/AppRoundedImage.Circle"
                 android:src="@drawable/background_gray_300"/>
 
             <TextView
-                android:id="@+id/tv_social_post_item_nickname"
+                android:id="@+id/tv_social_detail_post_item_nickname"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="7dp"
@@ -170,7 +170,7 @@
                 android:text="닉네임닉네임닉네임"/>
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/btn_following_following"
+                android:id="@+id/btn_social_detail_following_following"
                 style="@style/FollowingButtonStyle"
                 android:layout_width="50dp"
                 android:layout_height="30dp"
@@ -186,21 +186,23 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:layout_marginStart="25dp"
+        android:layout_marginStart="28dp"
         android:layout_marginEnd="25dp"
+        android:layout_marginBottom="20dp"
         android:text="내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용"
-        android:textSize="14sp"
-        app:layout_constraintTop_toBottomOf="@+id/layout_title_and_author"
+        android:textSize="16sp"
+        app:layout_constraintTop_toBottomOf="@+id/layout_social_detail_title_and_author"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/divider_social_detail_comment"/>
 
     <!-- 디바이더 -->
     <View
-        android:id="@+id/comment_divider"
+        android:id="@+id/divider_social_detail_comment"
         android:layout_width="match_parent"
         android:layout_height="10dp"
         android:background="#D0D0D0"
-        android:layout_marginTop="10dp"
+        android:layout_marginTop="20dp"
         app:layout_constraintTop_toBottomOf="@id/tv_social_detail_content"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
@@ -210,22 +212,11 @@
         android:id="@+id/rv_social_detail_comment_list"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@+id/comment_divider"
+        app:layout_constraintTop_toBottomOf="@+id/divider_social_detail_comment"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toTopOf="@+id/commentInput"
         tools:listitem="@layout/row_social_comment" />
-
-    <!-- 디바이더 -->
-    <View
-        android:id="@+id/comment_edit_text_divider"
-        android:layout_width="match_parent"
-        android:layout_height="10dp"
-        android:background="#D0D0D0"
-        android:layout_marginTop="10dp"
-        app:layout_constraintTop_toBottomOf="@id/tv_social_detail_content"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
 
     <!-- 댓글 입력창 -->
     <LinearLayout

--- a/app/src/main/res/layout/fragment_social_detail.xml
+++ b/app/src/main/res/layout/fragment_social_detail.xml
@@ -158,8 +158,9 @@
                 android:id="@+id/iv_social_detail_post_item_profile_picture"
                 android:layout_width="30dp"
                 android:layout_height="30dp"
+                android:scaleType="centerCrop"
                 app:shapeAppearanceOverlay="@style/AppRoundedImage.Circle"
-                android:src="@drawable/background_gray_300"/>
+                android:src="@drawable/ic_default_profile"/>
 
             <TextView
                 android:id="@+id/tv_social_detail_post_item_nickname"

--- a/app/src/main/res/layout/fragment_social_detail.xml
+++ b/app/src/main/res/layout/fragment_social_detail.xml
@@ -69,7 +69,7 @@
 
         <!-- 태그 핀 FrameLayout -->
         <FrameLayout
-            android:id="@+id/fl__social_detail_tag_pin_overlay"
+            android:id="@+id/fl_social_detail_tag_pin_overlay"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
     </FrameLayout>

--- a/app/src/main/res/navigation/customer_nav_graph.xml
+++ b/app/src/main/res/navigation/customer_nav_graph.xml
@@ -218,7 +218,6 @@
         android:label="fragment_social_following_all"
         tools:layout="@layout/fragment_social_following_all" />
 
-    <!-- Social Write Picture Fragment -->
     <fragment
         android:id="@+id/socialWritePictureFragment"
         android:name="com.nemodream.bangkkujaengi.customer.ui.fragment.SocialWritePictureFragment"
@@ -228,7 +227,11 @@
         android:id="@+id/socialDetailFragment"
         android:name="com.nemodream.bangkkujaengi.customer.ui.fragment.SocialDetailFragment"
         android:label="fragment_social_detail"
-        tools:layout="@layout/fragment_social_detail" />
+        tools:layout="@layout/fragment_social_detail">
+<!--        <argument-->
+<!--            android:name="post"-->
+<!--            app:argType="com.nemodream.bangkkujaengi.customer.data.model.Post" />-->
+    </fragment>
 
 
     <fragment


### PR DESCRIPTION
## 해결한 문제
- 상세페이지 데이터 연동
- 이미지 저장 경로 "https://..."로 수정
- 게시글 상세와 팔로잉 탭에서 팔로잉/팔로워 데이터 처리
<br/>

## 풀지 못한 문제
-  비회원인 경우 소셜 입장 불가
    - 막으려고 CustomerActivity의 line129 ~ line146 작성했는데 잘 안됩니다
- 저장됨 기능은 구현 못했습니다.. 
- 상세 게시글에서 List<Tag>를 못들고 오고 있습니다.
    - 저장할때는 List<Tag>로 잘 저장하는데, 데이터 베이스에 자동으로 JSON으로 바껴 저장되어서 해시맵 형태로 저장됩니다. 
    - 그래서 데이터를 코드로 들고올때 클래스어셉션 나면서 <Tag>형태로 바꿔라하는데 잘 안됩니다. 
    - 해시의 값을 직접 쓰는 방법도 해봤는데 직접적으로 쓰진 못하는것 같습니다.
<br/>

## 풀고있는 문제
- 팔로잉 전체 프래그먼트에서 팔로잉/팔로우 데이터 처리  
<br/>

## 기타
- 마이페이지에 프로필 수정 기능이 있어서 소셜의 프로필 수정 기능은 중요도가 낮아진것 같은데, 편집 아이콘 삭제해도 될까요?
<br/>

## 최종적으로 못하는 기능
- 게시글 저장
- 상세페이지에 태그 보여주기
- 댓글  
<br/>
